### PR TITLE
Using local etcd endpoint for kine integration

### DIFF
--- a/docs/getting-started-with-kamaji.md
+++ b/docs/getting-started-with-kamaji.md
@@ -49,7 +49,7 @@ Once a compatible-mysql database is running, we need to provide information abou
 --kine-mysql-host=<database host>
 --kine-mysql-port=<database port>
 --kine-mysql-secret-name=<secret name>
---kine-mysql-secret-name=<secret namespace>
+--kine-mysql-secret-namespace=<secret namespace>
 ```
 
 The secret with the configuration and certificates for mysql should look like:

--- a/internal/types/etcd_storage.go
+++ b/internal/types/etcd_storage.go
@@ -1,14 +1,16 @@
 package types
 
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
 type ETCDStorageType int
 
 const (
 	ETCD ETCDStorageType = iota
 	KineMySQL
-)
-
-const (
-	defaultETCDStorageType = ETCD
 )
 
 var etcdStorageTypeString = map[string]ETCDStorageType{"etcd": ETCD, "kine-mysql": KineMySQL}
@@ -23,6 +25,17 @@ func ParseETCDStorageType(s string) ETCDStorageType {
 		return storageType
 	}
 
-	// TODO: we have to decide what to do in this situation
-	return defaultETCDStorageType
+	panic(fmt.Errorf("unsupported storage type %s", s))
+}
+
+// ParseETCDEndpoint returns the default ETCD endpoints used to interact with the Tenant Control Plane backing storage.
+func ParseETCDEndpoint(conf *viper.Viper) string {
+	switch ParseETCDStorageType(conf.GetString("etcd-storage-type")) {
+	case ETCD:
+		return conf.GetString("etcd-endpoints")
+	case KineMySQL:
+		return "127.0.0.1:2379"
+	default:
+		panic("unsupported storage type")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 			ETCDCASecretNamespace:     conf.GetString("etcd-ca-secret-namespace"),
 			ETCDClientSecretName:      conf.GetString("etcd-client-secret-name"),
 			ETCDClientSecretNamespace: conf.GetString("etcd-client-secret-namespace"),
-			ETCDEndpoints:             conf.GetString("etcd-endpoints"),
+			ETCDEndpoints:             types.ParseETCDEndpoint(conf),
 			ETCDCompactionInterval:    conf.GetString("etcd-compaction-interval"),
 			TmpBaseDirectory:          conf.GetString("tmp-directory"),
 			KineMySQLSecretName:       conf.GetString("kine-mysql-secret-name"),


### PR DESCRIPTION
This PR aims to address the issues faced during the [Kine integration with MySQL review](https://github.com/clastix/kamaji/pull/66#pullrequestreview-1027090332).

Controller logs after the following changes:

```
1.6570057426612568e+09  INFO    controller.tenantcontrolplane   coredns has been configured     {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default"}
1.6570057429087956e+09  INFO    controller.tenantcontrolplane   kubeproxy has been configured   {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default"}
1.6570057433136468e+09  INFO    controller.tenantcontrolplane   test has been reconciled        {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default"}
```

Tenant Control Plane pods result:

```
NAME                   READY   STATUS    RESTARTS   AGE
test-549c8f8c9-wvcwq   4/4     Running   0          6m54s
```

Evaluating access to the Tenant Control Plane:

```
KUBECONFIG=/tmp/test kubectl version

Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.4", GitCommit:"b695d79d4f967c403a96986f1750a35eb75e75f1", GitTreeState:"clean", BuildDate:"2021-11-17T15:48:33Z", GoVersion:"go1.16.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.1", GitCommit:"86ec240af8cbd1b60bcc4c03c20da9b98005b92e", GitTreeState:"clean", BuildDate:"2021-12-16T11:34:54Z", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}
```